### PR TITLE
Shrink To Fit

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -9,9 +9,12 @@ var options = {
         },
         style: {
             fontSize: 10,
-            badgeSize: 10,
-            badgeMarginRight: 1,
-            lineSpacing: 5
+            minFontSize: 3,
+            /*
+            badgeSize: =fontSize
+            badgeMarginRight: =fontSize*0.25 (no less than 1)
+            */
+            lineSpacing: 5,
         }
     }
 };

--- a/src/renderers.js
+++ b/src/renderers.js
@@ -7,9 +7,9 @@ function CanvasLegend(plot, opts) {
     this.badgeSize = this.opts.legend.style.badgeSize;
     this.badgeMarginRight = this.opts.legend.style.badgeMarginRight;
     this.fontSize = this.opts.legend.style.fontSize;
-    this.lineWidth = this.getLineWidth();
+    this.lineHeight = this.getLineHeight();
 }
-CanvasLegend.prototype.getLineWidth = function() {
+CanvasLegend.prototype.getLineHeight = function() {
 
     return this.opts.legend.style.lineSpacing + Math.max(this.opts.legend.style.badgeSize, this.opts.legend.style.fontSize);
 };
@@ -34,7 +34,7 @@ CanvasLegend.prototype.getLegendHeight = function() {
         numberOfLines++;
     }
 
-    return numberOfLines * this.lineWidth + options.legend.margin.top + options.legend.margin.bottom;
+    return numberOfLines * this.lineHeight + options.legend.margin.top + options.legend.margin.bottom;
 };
 CanvasLegend.prototype.beforeDraw = function() {
 
@@ -66,7 +66,7 @@ CanvasLegend.prototype.drawBadge = function(color) {
     this.ctx.fillRect(this.x, this.y, this.badgeSize, this.badgeSize);
 
     this.ctx.beginPath();
-    this.ctx.lineWidth = "0.5";
+    this.ctx.lineHeight = "0.5";
     this.ctx.strokeStyle = "black";
     this.ctx.rect(this.x, this.y, this.badgeSize, this.badgeSize);
     this.ctx.stroke();
@@ -75,7 +75,7 @@ CanvasLegend.prototype.drawBadge = function(color) {
 };
 CanvasLegend.prototype.drawNewline = function() {
 
-    this.y = this.lineWidth + this.y;
+    this.y = this.lineHeight + this.y;
     this.x = this.xMin;
 };
 CanvasLegend.prototype.afterDraw = function() {

--- a/src/renderers.js
+++ b/src/renderers.js
@@ -4,15 +4,47 @@ function CanvasLegend(plot, opts) {
 
     this.plot = plot;
     this.opts = opts;
-    this.badgeSize = this.opts.legend.style.badgeSize;
-    this.badgeMarginRight = this.opts.legend.style.badgeMarginRight;
-    this.fontSize = this.opts.legend.style.fontSize;
-    this.lineHeight = this.getLineHeight();
+    this.doRender = true;
+    this.setFontSize(this.opts.legend.style.fontSize);
 }
+
+CanvasLegend.prototype.setDryRun = function(dryRun) {
+    this.doRender = !dryRun;
+};
+
+CanvasLegend.prototype.getFontSize = function() {
+
+    return this.badgeSize;
+};
+
+CanvasLegend.prototype.setFontSize = function(size) {
+
+    this.fontSize = size;
+    this.badgeSize = size;
+    this.badgeMarginRight = Math.max(1, Math.round(size * 0.25));
+    this.lineHeight = this.getLineHeight();
+};
+
+CanvasLegend.prototype.getBadgeSize = function() {
+
+    return this.badgeSize;
+};
+
+CanvasLegend.prototype.updateMaxWidth = function() {
+
+    this.maxWidth = Math.max(this.maxWidth, this.x);
+};
+
+CanvasLegend.prototype.getMaxWidth = function() {
+
+    return this.maxWidth;
+};
+
 CanvasLegend.prototype.getLineHeight = function() {
 
-    return this.opts.legend.style.lineSpacing + Math.max(this.opts.legend.style.badgeSize, this.opts.legend.style.fontSize);
+    return this.opts.legend.style.lineSpacing + Math.max(this.badgeSize, this.fontSize);
 };
+
 CanvasLegend.prototype.getLegendHeight = function() {
 
     // Count the number of lines
@@ -36,6 +68,7 @@ CanvasLegend.prototype.getLegendHeight = function() {
 
     return numberOfLines * this.lineHeight + options.legend.margin.top + options.legend.margin.bottom;
 };
+
 CanvasLegend.prototype.beforeDraw = function() {
 
     this.ctx = this.plot.getCanvas().getContext('2d');
@@ -49,36 +82,50 @@ CanvasLegend.prototype.beforeDraw = function() {
     // Initial coordinates
     this.x = this.xMin;
     this.y = this.yMin;
+
+    this.maxWidth = this.x;
 };
+
 CanvasLegend.prototype.drawText = function(text) {
 
     this.ctx.fillStyle = "black";
     this.ctx.font = this.fontSize + "px Monospace";
     this.ctx.textAlign = "left";
-    this.ctx.fillText(text, this.x, this.y + this.fontSize);
+
+    if (this.doRender) {
+        this.ctx.fillText(text, this.x, this.y + this.fontSize);
+    }
 
     var textSize = this.ctx.measureText(text);
     this.x += textSize.width;
+    this.updateMaxWidth();
 };
+
 CanvasLegend.prototype.drawBadge = function(color) {
 
-    this.ctx.fillStyle = color;
-    this.ctx.fillRect(this.x, this.y, this.badgeSize, this.badgeSize);
+    if (this.doRender) {
+        this.ctx.fillStyle = color;
+        this.ctx.fillRect(this.x, this.y, this.badgeSize, this.badgeSize);
 
-    this.ctx.beginPath();
-    this.ctx.lineHeight = "0.5";
-    this.ctx.strokeStyle = "black";
-    this.ctx.rect(this.x, this.y, this.badgeSize, this.badgeSize);
-    this.ctx.stroke();
+        this.ctx.beginPath();
+        this.ctx.lineHeight = "0.5";
+        this.ctx.strokeStyle = "black";
+        this.ctx.rect(this.x, this.y, this.badgeSize, this.badgeSize);
+        this.ctx.stroke();
+    }
 
     this.x += this.badgeSize + this.badgeMarginRight;
+    this.updateMaxWidth();
 };
+
 CanvasLegend.prototype.drawNewline = function() {
 
     this.y = this.lineHeight + this.y;
     this.x = this.xMin;
 };
-CanvasLegend.prototype.afterDraw = function() {
 
-    this.ctx.save();
+CanvasLegend.prototype.afterDraw = function() {
+    if (this.doRender) {
+        this.ctx.save();
+    }
 };

--- a/test/jquery.flot.legend.test.js
+++ b/test/jquery.flot.legend.test.js
@@ -181,11 +181,11 @@ describe('jquery.flot.legend', function () {
     describe('CanvasLegend renderer', function() {
         var opts = JSON.parse(JSON.stringify(options));
 
-        describe('.getLineWidth', function() {
+        describe('.getLineHeight', function() {
             it('should return a sensible default', function () {
 
                 var renderer = new CanvasLegend(null, opts);
-                expect(renderer.getLineWidth()).toBe(15);
+                expect(renderer.getLineHeight()).toBe(15);
             });
         });
 


### PR DESCRIPTION
Add support for "shrink-to-fit" so that the fontSize option is now, essentially, a "max font size", and it will attempt to shrink the font size until it fits the canvas (down to a minimum font size, configured with the minFontSize legend option).

This patch also removes the "badgeSize" and "badgeMarginRight" options. Instead, badgeSize always matches fontSize, and badgeMarginRight is fontSize \* 0.25 or 1, whichever is greater.
